### PR TITLE
PLAT-183 Add MongoDB SSL support

### DIFF
--- a/mongodb/mongodb/mongodb.tf
+++ b/mongodb/mongodb/mongodb.tf
@@ -36,6 +36,9 @@ variable "config_ebs" {
 variable "role_node" {
   default = "false"
 }
+variable "role_monitoring" {
+  default = "false"
+}
 variable "role_opsmanager" {
   default = "false"
 }
@@ -74,6 +77,7 @@ data "template_file" "user_data" {
     config_ephemeral         = "${var.config_ephemeral}"
     config_ebs               = "${var.config_ebs}"
     role_node                = "${var.role_node}"
+    role_monitoring          = "${var.role_monitoring}"
     role_opsmanager          = "${var.role_opsmanager}"
     role_backup              = "${var.role_backup}"
     mms_group_id             = "${var.mms_group_id}"

--- a/mongodb/mongodb/mongodb.tf
+++ b/mongodb/mongodb/mongodb.tf
@@ -6,6 +6,8 @@ variable "mongodb_conf_engine"      {}
 variable "mongodb_conf_replsetname" {}
 variable "mongodb_conf_oplogsizemb" {}
 variable "mongodb_key_s3_object"    {}
+variable "mongodb_ssl_server_key_s3_object" {}
+variable "mongodb_ssl_client_key_s3_object" {}
 variable "opsmanager_key_s3_object" {}
 variable "mongodb_iam_name"         {}
 variable "mongodb_sg_id"            {}
@@ -63,6 +65,8 @@ data "template_file" "user_data" {
     mongodb_conf_replsetname = "${var.mongodb_conf_replsetname}"
     mongodb_conf_oplogsizemb = "${var.mongodb_conf_oplogsizemb}"
     mongodb_key_s3_object    = "${var.mongodb_key_s3_object}"
+    mongodb_ssl_server_key_s3_object = "${var.mongodb_ssl_server_key_s3_object}"
+    mongodb_ssl_client_key_s3_object = "${var.mongodb_ssl_client_key_s3_object}"
     opsmanager_key_s3_object = "${var.opsmanager_key_s3_object}"
     opsmanager_subdomain     = "${var.opsmanager_subdomain}"
     hostname                 = "${var.route53_hostname}"

--- a/mongodb/mongodb/mongodb.tf
+++ b/mongodb/mongodb/mongodb.tf
@@ -36,7 +36,10 @@ variable "config_ebs" {
 variable "role_node" {
   default = "false"
 }
-variable "role_monitoring" {
+variable "role_monitoring_agent" {
+  default = "false"
+}
+variable "role_backup_agent" {
   default = "false"
 }
 variable "role_opsmanager" {
@@ -77,7 +80,8 @@ data "template_file" "user_data" {
     config_ephemeral         = "${var.config_ephemeral}"
     config_ebs               = "${var.config_ebs}"
     role_node                = "${var.role_node}"
-    role_monitoring          = "${var.role_monitoring}"
+    role_monitoring_agent    = "${var.role_monitoring_agent}"
+    role_backup_agent        = "${var.role_backup_agent}"
     role_opsmanager          = "${var.role_opsmanager}"
     role_backup              = "${var.role_backup}"
     mms_group_id             = "${var.mms_group_id}"

--- a/mongodb/mongodb/templates/user-data.sh
+++ b/mongodb/mongodb/templates/user-data.sh
@@ -201,7 +201,7 @@ if [ "${role_node}" == "true" ]; then
   # Automation Agent won't start without proper hostname resolution, but Route53 takes a few mins to propagate.
   echo "`curl http://169.254.169.254/latest/meta-data/local-ipv4` ${hostname}" >> /etc/hosts
 
-  # setup ssl certificates
+  # setup ssl certificates for mongodb
   SSL_PATH=/etc/mongodb/ssl
   mkdir -p $SSL_PATH
   aws s3 --region=${aws_region} cp ${mongodb_ssl_server_key_s3_object} $SSL_PATH/mongodb_ssl_server.pem
@@ -211,6 +211,35 @@ if [ "${role_node}" == "true" ]; then
 
   service mongodb-mms-automation-agent stop
   service mongodb-mms-automation-agent start
+fi
+
+#
+# Monitoring Agent (connects to OpsManager)
+#
+if [ "${role_monitoring}" == "true" ] ; then
+  # install
+  curl -k -OL http://opsmanager.universe.com:8080/download/agent/monitoring/mongodb-mms-monitoring-agent_5.4.5.370-1_amd64.deb
+  DEBIAN_FRONTEND=noninteractive dpkg --install mongodb-mms-monitoring-agent_5.4.5.370-1_amd64.deb
+
+  # setup for opsmanager
+  MONITORING_AGENT_CONFIG_FILE=/etc/mongodb-mms/monitoring-agent.config
+  OPSMANAGER_URL=`echo http://${opsmanager_subdomain}:8080 | awk '{gsub("/", "\\\/");print}'`
+  sed -i "s/mmsBaseUrl=.*/mmsBaseUrl=$OPSMANAGER_URL/" $MONITORING_AGENT_CONFIG_FILE
+  sed -i "s/mmsApiKey=.*/mmsApiKey=${mms_api_key}/" $MONITORING_AGENT_CONFIG_FILE
+
+  # setup ssl certificates for monitoring agents
+  SSL_PATH=/etc/mongodb-mms/ssl
+  mkdir -p $SSL_PATH
+  aws s3 --region=${aws_region} cp ${mongodb_ssl_server_key_s3_object} $SSL_PATH/mongodb_ssl_server.pem
+  aws s3 --region=${aws_region} cp ${mongodb_ssl_client_key_s3_object} $SSL_PATH/mongodb_ssl_client.pem
+  chmod 700 -R $SSL_PATH
+  chown -R mongodb-mms-agent:mongodb-mms-agent $SSL_PATH
+  echo "sslTrustedServerCertificates=$SSL_PATH/mongodb_ssl_server.pem" >> $MONITORING_AGENT_CONFIG_FILE
+  echo "sslClientCertificate=$SSL_PATH/mongodb_ssl_client.pem"         >> $MONITORING_AGENT_CONFIG_FILE
+  echo "sslRequireValidServerCertificates=true"                        >> $MONITORING_AGENT_CONFIG_FILE
+
+  stop mongodb-mms-monitoring-agent
+  start mongodb-mms-monitoring-agent
 fi
 
 #

--- a/mongodb/mongodb/templates/user-data.sh
+++ b/mongodb/mongodb/templates/user-data.sh
@@ -216,16 +216,16 @@ fi
 #
 # Monitoring Agent (connects to OpsManager)
 #
-if [ "${role_monitoring}" == "true" ] ; then
+if [ "${role_monitoring_agent}" == "true" ] ; then
   # install
-  curl -k -OL http://opsmanager.universe.com:8080/download/agent/monitoring/mongodb-mms-monitoring-agent_5.4.5.370-1_amd64.deb
+  curl -k -OL http://${opsmanager_subdomain}:8080/download/agent/monitoring/mongodb-mms-monitoring-agent_5.4.5.370-1_amd64.deb
   DEBIAN_FRONTEND=noninteractive dpkg --install mongodb-mms-monitoring-agent_5.4.5.370-1_amd64.deb
 
   # setup for opsmanager
   MONITORING_AGENT_CONFIG_FILE=/etc/mongodb-mms/monitoring-agent.config
-  OPSMANAGER_URL=`echo http://${opsmanager_subdomain}:8080 | awk '{gsub("/", "\\\/");print}'`
-  sed -i "s/mmsBaseUrl=.*/mmsBaseUrl=$OPSMANAGER_URL/" $MONITORING_AGENT_CONFIG_FILE
-  sed -i "s/mmsApiKey=.*/mmsApiKey=${mms_api_key}/" $MONITORING_AGENT_CONFIG_FILE
+  ESCAPED_OPSMANAGER_URL=`echo http://${opsmanager_subdomain}:8080 | awk '{gsub("/", "\\\/");print}'`
+  sed -i "s/mmsBaseUrl=.*/mmsBaseUrl=$ESCAPED_OPSMANAGER_URL/"        $MONITORING_AGENT_CONFIG_FILE
+  sed -i "s/mmsApiKey=.*/mmsApiKey=${mms_api_key}/"                   $MONITORING_AGENT_CONFIG_FILE
 
   # setup ssl certificates for monitoring agents
   SSL_PATH=/etc/mongodb-mms/ssl
@@ -240,6 +240,36 @@ if [ "${role_monitoring}" == "true" ] ; then
 
   stop mongodb-mms-monitoring-agent
   start mongodb-mms-monitoring-agent
+fi
+
+#
+# Backup Agent (connects to OpsManager)
+#
+if [ "${role_backup_agent}" == "true" ] ; then
+  # install
+  curl -k -OL http://${opsmanager_subdomain}:8080/download/agent/backup/mongodb-mms-backup-agent_5.0.7.494-1_amd64.deb
+  DEBIAN_FRONTEND=noninteractive dpkg --install mongodb-mms-backup-agent_5.0.7.494-1_amd64.deb
+
+  # setup for opsmanager
+  BACKUP_AGENT_CONFIG_FILE=/etc/mongodb-mms/backup-agent.config
+  chmod 644 $BACKUP_AGENT_CONFIG_FILE
+  chown mongodb:mongodb $BACKUP_AGENT_CONFIG_FILE
+  sed -i "s/mmsApiKey=.*/mmsApiKey=${mms_api_key}/"                 $BACKUP_AGENT_CONFIG_FILE
+  sed -i "s/mothership=.*/mothership=${opsmanager_subdomain}:8080/" $BACKUP_AGENT_CONFIG_FILE
+
+  # setup ssl certificates for monitoring agents
+  SSL_PATH=/etc/mongodb-mms/ssl
+  mkdir -p $SSL_PATH
+  aws s3 --region=${aws_region} cp ${mongodb_ssl_server_key_s3_object} $SSL_PATH/mongodb_ssl_server.pem
+  aws s3 --region=${aws_region} cp ${mongodb_ssl_client_key_s3_object} $SSL_PATH/mongodb_ssl_client.pem
+  chmod 700 -R $SSL_PATH
+  chown -R mongodb-mms-agent:mongodb-mms-agent $SSL_PATH
+  echo "sslTrustedServerCertificates=$SSL_PATH/mongodb_ssl_server.pem" >> $BACKUP_AGENT_CONFIG_FILE
+  echo "sslClientCertificate=$SSL_PATH/mongodb_ssl_client.pem"         >> $BACKUP_AGENT_CONFIG_FILE
+  echo "sslRequireValidServerCertificates=true"                        >> $BACKUP_AGENT_CONFIG_FILE
+
+  stop mongodb-mms-backup-agent
+  start mongodb-mms-backup-agent
 fi
 
 #
@@ -279,8 +309,4 @@ EOF
   sed -i "s/\/etc\/mongod.conf/\/etc\/mongod-backup.conf/g" /etc/init/mongod-backup.conf
   sed -i "s/\/etc\/default\/mongod/\/etc\/default\/mongod-backup/g" /etc/init/mongod-backup.conf
   service mongod-backup start
-
-  curl -k -OL http://${opsmanager_subdomain}:8080/download/agent/backup/mongodb-mms-backup-agent_5.0.7.494-1_amd64.deb
-  dpkg --install mongodb-mms-backup-agent_5.0.7.494-1_amd64.deb
-  service mongodb-mms-backup-agent start
 fi

--- a/mongodb/mongodb/templates/user-data.sh
+++ b/mongodb/mongodb/templates/user-data.sh
@@ -201,6 +201,14 @@ if [ "${role_node}" == "true" ]; then
   # Automation Agent won't start without proper hostname resolution, but Route53 takes a few mins to propagate.
   echo "`curl http://169.254.169.254/latest/meta-data/local-ipv4` ${hostname}" >> /etc/hosts
 
+  # setup ssl certificates
+  SSL_PATH=/etc/mongodb/ssl
+  mkdir -p $SSL_PATH
+  aws s3 --region=${aws_region} cp ${mongodb_ssl_server_key_s3_object} $SSL_PATH/mongodb_ssl_server.pem
+  aws s3 --region=${aws_region} cp ${mongodb_ssl_client_key_s3_object} $SSL_PATH/mongodb_ssl_client.pem
+  chmod 700 -R $SSL_PATH
+  chown -R mongodb:mongodb $SSL_PATH
+
   service mongodb-mms-automation-agent stop
   service mongodb-mms-automation-agent start
 fi


### PR DESCRIPTION
Can't configure SSL for monitoring + backup agents through Ops Manager. There are some bugs, wrote to support. Install and configure them manually